### PR TITLE
chore: Create Rust toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
There is no evidence pointing towards this package requiring the nightly toolchain without running a build and being greeted with errors, this solves that.