### PR TITLE
feature: import statements

### DIFF
--- a/examples/import.koi
+++ b/examples/import.koi
@@ -1,0 +1,6 @@
+import "module/double"
+import "module/fibonacci.koi"
+
+print(double(2))
+
+print(fib(5))

--- a/examples/module/double.koi
+++ b/examples/module/double.koi
@@ -1,0 +1,3 @@
+fn double(n) {
+    return n * 2
+}

--- a/examples/module/fibonacci.koi
+++ b/examples/module/fibonacci.koi
@@ -1,0 +1,7 @@
+fn fib(n) {
+    if n <= 1 {
+        return n
+    } else {
+        return fib(n - 1) + fib(n - 2)
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -77,6 +77,7 @@ pub enum Expr {
 pub enum Stmt {
     Expr(Expr),
     Cmd(Cmd),
+    Import(String),
     Let {
         is_exp: bool,
         name: String,

--- a/src/lexer/raw.rs
+++ b/src/lexer/raw.rs
@@ -189,6 +189,7 @@ impl RawLexer {
         let word: String = iter.take_while_ref(|&&c| can_start_word(c) || c.is_ascii_digit()).collect();
 
         let kw_kind = match word.as_ref() {
+            "import" => Some(TokenKind::Import),
             "for" => Some(TokenKind::For),
             "in" => Some(TokenKind::In),
             "while" => Some(TokenKind::While),

--- a/src/lexer/test.rs
+++ b/src/lexer/test.rs
@@ -28,7 +28,15 @@ fn scans_spaces() {
 
 #[test]
 fn scans_keywords() {
-    assert_eq!(scan("while for return continue"), vec![
+    assert_eq!(scan("import while for return continue"), vec![
+        Token {
+            kind: TokenKind::Import,
+            lexeme: "import".to_owned(),
+        },
+        Token {
+            kind: TokenKind::Space,
+            lexeme: " ".to_owned(),
+        },
         Token {
             kind: TokenKind::While,
             lexeme: "while".to_owned(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn main() {
 
     let mut interpreter = interp::Interpreter::new();
     interpreter.set_args(script_args);
+    interpreter.set_root(matches.value_of("path").unwrap());
     interpreter.run(prog);
 
     if let Some(f) = matches.value_of("fn") {

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -371,6 +371,13 @@ fn parses_break() {
 }
 
 #[test]
+fn parses_import() {
+    assert_eq!(parse("import \"module/file\""), vec![
+        Stmt::Import("module/file".to_owned()),
+    ]);
+}
+
+#[test]
 fn parses_if() {
     assert_eq!(parse("if true {\ncmd_if_true\n}"), vec![
         Stmt::If {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -13,6 +13,7 @@ pub enum TokenKind {
         does_interp: bool,
     },
 
+    Import,
     For,
     In,
     While,


### PR DESCRIPTION
I'm currently building my own programming language that is a bit more JavaScript / PHP like but I've been very interested in Koi since seeing it on Reddit a couple of days ago.

I've just implemented `import` statements in my own language and thought I'd contribute to Koi with the same functionality.

There's definitely some improvements that can be made...

```
// src/main.koi
import "modules/double"

print(double(2)) // Expected: 4
```

```
// src/modules/double.koi

fn double(n) {
    return n * 2
}
```

All the `import` statement does is expect a string literal to follow. It then stores this path and will run the file's AST through the same interpreter instance (so environment etc is maintained and all imports are available to the calling file).

The interpreter will now also store the root directory of the program. It takes the input / source file and gets the parent directory. All imports are resolved relative to the source / entry file.

The file extension is completely optional too. You could import the file using `modules/double` or `modules/double.koi` (like JavaScript).

There's room here for future additions like standard library / modules that Koi provides to keep the global namespace empty, named imports, aliases imports, etc.

Let me know what you think!

P.s. the architecture of Koi is very different to my language (tree-walk interpreter vs byte code VM) so if I've misunderstood something, please tell me.