### PR TITLE
feature: function argument type hints

### DIFF
--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -4,7 +4,7 @@ fn double(n: number) {
 
 print(double(2))
 
-fn is_true(op: string | bool) {
+fn is_true(op: string | bool) -> bool {
     return !! op
 }
 

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -12,7 +12,7 @@ print(is_true("hello"))
 print(is_true(true))
 print(is_true(false))
 
-fn nil_return() -> bool {
+fn nil_return() -> nil {
 
 }
 

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -1,4 +1,4 @@
-fn double(n: string) {
+fn double(n: number) {
     return n * 2
 }
 

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -11,3 +11,9 @@ fn is_true(op: string | bool) -> bool {
 print(is_true("hello"))
 print(is_true(true))
 print(is_true(false))
+
+fn nil_return() -> bool {
+
+}
+
+nil_return()

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -3,3 +3,11 @@ fn double(n: number) {
 }
 
 print(double(2))
+
+fn is_true(op: string | bool) {
+    return !! op
+}
+
+print(is_true("hello"))
+print(is_true(true))
+print(is_true(false))

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -1,0 +1,5 @@
+fn double(n: string) {
+    return n * 2
+}
+
+print(double(2))

--- a/examples/type-hints.koi
+++ b/examples/type-hints.koi
@@ -8,6 +8,12 @@ fn is_true(op: string | bool) -> bool {
     return !! op
 }
 
+fn nil_argument(arg: nil) {
+    return arg
+}
+
+nil_argument(nil)
+
 print(is_true("hello"))
 print(is_true(true))
 print(is_true(false))

--- a/src/interp/func.rs
+++ b/src/interp/func.rs
@@ -15,6 +15,8 @@ pub enum Func {
         params: Vec<FuncParam>,
         body: Box<Stmt>,
         captured_env: Option<Rc<RefCell<Env>>>,
+        has_return_type: bool,
+        return_type: Option<String>,
     },
     Native {
         name: String,

--- a/src/interp/func.rs
+++ b/src/interp/func.rs
@@ -6,12 +6,13 @@ use std::rc::Rc;
 use crate::ast::Stmt;
 use crate::interp::{Interpreter, Value};
 use crate::interp::env::Env;
+use crate::parser::func::FuncParam;
 
 #[derive(Clone)]
 pub enum Func {
     User {
         name: Option<String>,
-        params: Vec<String>,
+        params: Vec<FuncParam>,
         body: Box<Stmt>,
         captured_env: Option<Rc<RefCell<Env>>>,
     },

--- a/src/interp/mod.rs
+++ b/src/interp/mod.rs
@@ -491,7 +491,7 @@ impl Interpreter {
                 for (p, arg) in params.into_iter().zip(args.into_iter()) {
                     if p.has_type_hint && !p.type_hints.is_empty() {
                         if ! p.type_hints.iter().any(|t| *t == arg.to_type_string()) {
-                            panic!("argument `{}` for function `{}` must be of type `{}`, got type `{}` instead", p.name, name.unwrap(), p.type_hints.join(", "), arg.to_type_string());
+                            panic!("argument `{}` for function `{}` must be of type `{}`, got type `{}` instead", p.name, name.unwrap(), p.type_hints.join(" | "), arg.to_type_string());
                         }
                     }
                     

--- a/src/interp/mod.rs
+++ b/src/interp/mod.rs
@@ -236,11 +236,13 @@ impl Interpreter {
             Stmt::Func(func) => {
                 match func {
                     // Lambdas don't get parsed as Stmt::Func but Expr::Lambda, therefore a name should always be present
-                    Func::User { name, params, body, .. } => {
+                    Func::User { name, params, body, return_type, has_return_type, .. } => {
                         let func = Value::Func(Func::User {
                             name: name.clone(),
                             params,
                             body,
+                            has_return_type,
+                            return_type, 
                             captured_env: Some(Rc::clone(&self.env)),
                         });
                         self.get_env_mut().def(name.unwrap(), func);
@@ -458,11 +460,13 @@ impl Interpreter {
                 self.call(func, args)
             }
             Expr::Lambda(func) => match func {
-                Func::User { name, params, body, .. } => Value::Func(Func::User {
+                Func::User { name, params, body, has_return_type, return_type, .. } => Value::Func(Func::User {
                     name,
                     params,
                     body,
                     captured_env: Some(Rc::clone(&self.env)),
+                    has_return_type,
+                    return_type
                 }),
                 Func::Native { .. } => unreachable!()
             }

--- a/src/interp/mod.rs
+++ b/src/interp/mod.rs
@@ -489,9 +489,9 @@ impl Interpreter {
                 let mut callee_env = mem::replace(&mut self.env, func_env);
 
                 for (p, arg) in params.into_iter().zip(args.into_iter()) {
-                    if p.has_type_hint && !p.type_hint.is_empty() {
-                        if p.type_hint.trim() != arg.to_type_string() {
-                            panic!("argument `{}` for function `{}` must be of type `{}`, got type `{}` instead", p.name, name.unwrap(), p.type_hint, arg.to_type_string());
+                    if p.has_type_hint && !p.type_hints.is_empty() {
+                        if ! p.type_hints.iter().any(|t| *t == arg.to_type_string()) {
+                            panic!("argument `{}` for function `{}` must be of type `{}`, got type `{}` instead", p.name, name.unwrap(), p.type_hints.join(", "), arg.to_type_string());
                         }
                     }
                     

--- a/src/interp/test.rs
+++ b/src/interp/test.rs
@@ -226,6 +226,20 @@ fn func_with_multiple_params_and_type_hints() {
 }
 
 #[test]
+fn func_with_nil_argument_type_hint() {
+    assert_eq!(
+        output("
+            fn test(a: nil) {
+                
+            }
+
+            test(nil)
+        "),
+        "".to_string()
+    );
+}
+
+#[test]
 fn func_with_return_type() {
     assert_eq!(
         output("

--- a/src/interp/test.rs
+++ b/src/interp/test.rs
@@ -183,6 +183,49 @@ fn func_no_return() {
 }
 
 #[test]
+fn func_with_single_type_hint() {
+    assert_eq!(
+        output("
+            fn double(n: number) {
+                return n * 2
+            }
+
+            print(double(2))
+        "),
+        "4\n".to_string()
+    );
+}
+
+#[test]
+fn func_with_union_type_hints() {
+    assert_eq!(
+        output("
+            fn noop(n: number | string) {
+                return n
+            }
+
+            print(noop(2))
+            print(noop(\"2\"))
+        "),
+        "2\n2\n".to_string()
+    );
+}
+
+#[test]
+fn func_with_multiple_params_and_type_hints() {
+    assert_eq!(
+        output("
+            fn add(a: number, b: number) {
+                return a + b
+            }
+
+            print(add(2, 2))
+        "),
+        "4\n".to_string()
+    );
+}
+
+#[test]
 #[should_panic]
 fn uncaught_break() {
     output("break");

--- a/src/interp/test.rs
+++ b/src/interp/test.rs
@@ -226,6 +226,34 @@ fn func_with_multiple_params_and_type_hints() {
 }
 
 #[test]
+fn func_with_return_type() {
+    assert_eq!(
+        output("
+            fn add(a: number, b: number) -> number {
+                return a + b
+            }
+
+            print(add(2, 2))
+        "),
+        "4\n".to_string()
+    );
+}
+
+#[test]
+fn func_with_nil_return_type() {
+    assert_eq!(
+        output("
+            fn add(a: number, b: number) -> nil {
+                return
+            }
+
+            add(2, 2)
+        "),
+        "".to_string()
+    );
+}
+
+#[test]
 #[should_panic]
 fn uncaught_break() {
     output("break");

--- a/src/interp/value.rs
+++ b/src/interp/value.rs
@@ -23,6 +23,21 @@ pub enum Value {
     Func(Func),
 }
 
+impl Value {
+    pub fn to_type_string(&self) -> String {
+        match self {
+            Value::Nil => "nil".to_owned(),
+            Value::Num(_) => "number".to_owned(),
+            Value::String(_) => "string".to_owned(),
+            Value::Bool(_) => "bool".to_owned(),
+            Value::Vec(_) => "vec".to_owned(),
+            Value::Dict(_) => "dict".to_owned(),
+            Value::Func(_) => "fn".to_owned(),
+            _ => "mixed".to_owned(),
+        }
+    }
+}
+
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/lexer/raw.rs
+++ b/src/lexer/raw.rs
@@ -118,6 +118,7 @@ impl RawLexer {
             },
             '-' => match self.char_at(1) {
                 Some('=') => (TokenKind::MinusEqual, 2),
+                Some('>') => (TokenKind::Arrow, 2),
                 _ => (TokenKind::Minus, 1),
             },
 

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -96,11 +96,15 @@ impl Parser {
             loop {
                 self.lexer.consume_whitespace(self.is_multiline);
 
-                if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
-                    type_hints.push(type_hint);
-                } else {
-                    panic!("expected typehint");
-                }
+                match self.lexer.next() {
+                    Some(Token { kind: TokenKind::Identifier(type_hint), .. }) => {
+                        type_hints.push(type_hint);
+                    },
+                    Some(Token { kind: TokenKind::Nil, .. }) => {
+                        type_hints.push("nil".to_owned());
+                    },
+                    _ => panic!("expected type identifier"),
+                };
 
                 self.lexer.consume_whitespace(self.is_multiline);
 

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -43,7 +43,7 @@ impl Parser {
         let mut param = FuncParam {
             name: "".to_owned(),
             has_type_hint: false,
-            type_hint: "".to_owned()
+            type_hints: vec!["".to_owned()]
         };
 
         if let Some(Token { kind: TokenKind::Identifier(name), .. }) = self.lexer.next() {
@@ -58,14 +58,18 @@ impl Parser {
             self.lexer.next();
 
             param.has_type_hint = true;
-        }
 
-        self.lexer.consume_whitespace(self.is_multiline);
+            self.lexer.consume_whitespace(self.is_multiline);
 
-        if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
-            param.type_hint = type_hint;
-        } else {
-            panic!("expected typehint");
+            let mut type_hints = vec![];
+
+            if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
+                type_hints.push(type_hint);
+            } else {
+                panic!("expected typehint");
+            }
+
+            param.type_hints = type_hints.clone();
         }
 
         param
@@ -76,5 +80,5 @@ impl Parser {
 pub struct FuncParam {
     pub name: String,
     pub has_type_hint: bool,
-    pub type_hint: String,
+    pub type_hints: Vec<String>,
 }

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -112,7 +112,7 @@ impl Parser {
                     Some(Token { kind: TokenKind::Pipe, .. }) => self.lexer.next(),
                     Some(Token { kind: TokenKind::RightParen, .. }) |
                     Some(Token { kind: TokenKind::Comma, .. }) => break,
-                    _ => panic!("unexpected token, expect pipe, comma or right paren")
+                    _ => panic!("unexpected token, expected pipe, comma or right paren")
                 };
             }
 

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -44,6 +44,9 @@ impl Parser {
                 Some(Token { kind: TokenKind::Identifier(type_hint), .. }) => {
                     return_type = Some(type_hint.clone());                    
                 },
+                Some(Token { kind: TokenKind::Nil, .. }) => {
+                    return_type = Some("nil".to_owned());
+                },
                 _ => panic!("expected type identifier")
             };
 

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -17,7 +17,7 @@ impl Parser {
         } else {
             loop {
                 self.lexer.consume_whitespace(self.is_multiline);
-                params.push(self.must_identifier());
+                params.push(self.must_identifier_maybe_with_type());
                 self.lexer.consume_whitespace(self.is_multiline);
 
                 match self.lexer.next() {
@@ -38,4 +38,43 @@ impl Parser {
             captured_env: None,
         }
     }
+
+    fn must_identifier_maybe_with_type(&mut self) -> FuncParam {
+        let mut param = FuncParam {
+            name: "".to_owned(),
+            has_type_hint: false,
+            type_hint: "".to_owned()
+        };
+
+        if let Some(Token { kind: TokenKind::Identifier(name), .. }) = self.lexer.next() {
+            param.name = name;
+        } else {
+            panic!("expected identifier");
+        }
+
+        self.lexer.consume_whitespace(self.is_multiline);
+
+        if let Some(Token { kind: TokenKind::Colon, .. }) = self.lexer.peek() {
+            self.lexer.next();
+
+            param.has_type_hint = true;
+        }
+
+        self.lexer.consume_whitespace(self.is_multiline);
+
+        if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
+            param.type_hint = type_hint;
+        } else {
+            panic!("expected typehint");
+        }
+
+        param
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FuncParam {
+    pub name: String,
+    pub has_type_hint: bool,
+    pub type_hint: String,
 }

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -110,8 +110,8 @@ impl Parser {
 
                 match self.lexer.peek() {
                     Some(Token { kind: TokenKind::Pipe, .. }) => self.lexer.next(),
-                    Some(Token { kind: TokenKind::RightParen, .. })
-                    | Some(Token { kind: TokenKind::Comma, .. }) => break,
+                    Some(Token { kind: TokenKind::RightParen, .. }) |
+                    Some(Token { kind: TokenKind::Comma, .. }) => break,
                     _ => panic!("unexpected token, expect pipe, comma or right paren")
                 };
             }

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -63,10 +63,23 @@ impl Parser {
 
             let mut type_hints = vec![];
 
-            if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
-                type_hints.push(type_hint);
-            } else {
-                panic!("expected typehint");
+            loop {
+                self.lexer.consume_whitespace(self.is_multiline);
+
+                if let Some(Token { kind: TokenKind::Identifier(type_hint), .. }) = self.lexer.next() {
+                    type_hints.push(type_hint);
+                } else {
+                    panic!("expected typehint");
+                }
+
+                self.lexer.consume_whitespace(self.is_multiline);
+
+                match self.lexer.peek() {
+                    Some(Token { kind: TokenKind::Pipe, .. }) => self.lexer.next(),
+                    Some(Token { kind: TokenKind::RightParen, .. })
+                    | Some(Token { kind: TokenKind::Comma, .. }) => break,
+                    _ => panic!("unexpected token, expect pipe, comma or right paren")
+                };
             }
 
             param.type_hints = type_hints.clone();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,7 +5,7 @@ use crate::token::{Token, TokenKind};
 mod expr;
 mod stmt;
 mod cmd;
-mod func;
+pub mod func;
 
 #[cfg(test)]
 mod test;

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -240,8 +240,8 @@ impl Parser {
 
         self.lexer.consume_whitespace(self.is_multiline);
 
-        let (params, body) = match self.continue_parse_fn() {
-            Func::User { params, body, .. } => (params, body),
+        let (params, body, has_return_type, return_type) = match self.continue_parse_fn() {
+            Func::User { params, body, has_return_type, return_type, .. } => (params, body, has_return_type, return_type),
             _ => unreachable!(),
         };
 
@@ -249,6 +249,8 @@ impl Parser {
             name: Some(name),
             params,
             body,
+            has_return_type: has_return_type,
+            return_type,
             captured_env: None,
         };
 

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -470,7 +470,23 @@ fn parses_fn() {
     assert_eq!(parse("fn foo \n( x , y , z ) \n {}"), vec![
         Stmt::Func(Func::User {
             name: Some("foo".to_owned()),
-            params: vec!["x".to_owned(), "y".to_owned(), "z".to_owned()],
+            params: vec![
+                func::FuncParam {
+                    name: "x".to_owned(),
+                    has_type_hint: false,
+                    type_hints: vec![],
+                },
+                func::FuncParam {
+                    name: "y".to_owned(),
+                    has_type_hint: false,
+                    type_hints: vec![],
+                },
+                func::FuncParam {
+                    name: "z".to_owned(),
+                    has_type_hint: false,
+                    type_hints: vec![],
+                }
+            ],
             body: Box::new(Stmt::Block(vec![])),
             captured_env: None,
         })

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -487,6 +487,8 @@ fn parses_fn() {
                     type_hints: vec![],
                 }
             ],
+            has_return_type: false,
+            return_type: None,
             body: Box::new(Stmt::Block(vec![])),
             captured_env: None,
         })
@@ -500,6 +502,8 @@ fn parses_fn_no_params() {
             name: Some("foo".to_owned()),
             params: vec![],
             body: Box::new(Stmt::Block(vec![])),
+            has_return_type: false,
+            return_type: None,
             captured_env: None,
         })
     ]);
@@ -530,6 +534,8 @@ fn parses_lambda() {
                     name: None,
                     params: vec![],
                     body: Box::new(Stmt::Block(vec![])),
+                    has_return_type: false,
+                    return_type: None,
                     captured_env: None,
                 })
             ],

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -63,6 +63,8 @@ pub enum TokenKind {
     AmperAmper,
     PipePipe,
 
+    Arrow,
+
     Comma,
     DotDot,
     Dot,


### PR DESCRIPTION
This pull requests adds support for function parameter types. It uses a similar syntax to Rust:

```
fn double(n: number) {
    return n * 2
}

print(double(2)) // prints 4.
print(double("2")) // panics because string, not a number.
```

You can also use union types:

```
fn is_true(x: string | bool) {
    return !!x
}

print(is_true("hello")) // prints `true`
print(is_true(true)) // prints `true`
print(is_true(false)) // prints false
```

I've added some tests too. The implementation is pretty solid and the runtime overhead is minimal, since it's only checked on initial call / invocation.