### PR TITLE
feature: bind dictionary to this inside of lambda

### DIFF
--- a/examples/dict-methods.koi
+++ b/examples/dict-methods.koi
@@ -1,0 +1,9 @@
+let obj = {
+    name: "Ryan",
+    age: 21,
+    description: fn () {
+        return " ".join([this.name, this.age])
+    }
+}
+
+print(obj.description())

--- a/src/interp/func.rs
+++ b/src/interp/func.rs
@@ -14,6 +14,7 @@ pub enum Func {
         params: Vec<String>,
         body: Box<Stmt>,
         captured_env: Option<Rc<RefCell<Env>>>,
+        receiver: Option<Box<Value>>,
     },
     Native {
         name: String,

--- a/src/interp/test.rs
+++ b/src/interp/test.rs
@@ -339,6 +339,20 @@ fn dict_method_bind_this() {
 }
 
 #[test]
+fn func_binding_this_nil() {
+    assert_eq!(
+        output("
+            fn test() {
+                return this
+            }
+
+            print(test())
+        "),
+        "nil\n".to_string()
+    );
+}
+
+#[test]
 fn native_vec_2_dict() {
     assert_eq!(output("print([['a', 1]].toDict())"), "{a: 1}\n".to_string());
 }

--- a/src/interp/test.rs
+++ b/src/interp/test.rs
@@ -322,6 +322,23 @@ fn native_clone_dict() {
 }
 
 #[test]
+fn dict_method_bind_this() {
+    assert_eq!(
+        output("
+            let obj = {
+                name: 'Ryan',
+                getName: fn () {
+                    return this.name
+                }
+            }
+
+            print(obj.getName())
+        "),
+        "Ryan\n".to_string()
+    );
+}
+
+#[test]
 fn native_vec_2_dict() {
     assert_eq!(output("print([['a', 1]].toDict())"), "{a: 1}\n".to_string());
 }

--- a/src/interp/value.rs
+++ b/src/interp/value.rs
@@ -23,6 +23,22 @@ pub enum Value {
     Func(Func),
 }
 
+impl Value {
+    pub fn bind_receiver(&mut self, this_context: Value) {
+        match self {
+            Value::Func(ref mut f) => {
+                match f {
+                    Func::User { ref mut receiver, .. } => {
+                        *receiver = Some(Box::new(this_context));
+                    },
+                    _ => panic!("cannot bind receiver to non-user fn")
+                };
+            },
+            _ => panic!("cannot bind receiver to non-dicts")
+        }
+    }
+}
+
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/parser/func.rs
+++ b/src/parser/func.rs
@@ -36,6 +36,7 @@ impl Parser {
             params,
             body: Box::new(body),
             captured_env: None,
+            receiver: None,
         }
     }
 }

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -250,6 +250,7 @@ impl Parser {
             params,
             body,
             captured_env: None,
+            receiver: None,
         };
 
         Stmt::Func(func)

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -473,6 +473,7 @@ fn parses_fn() {
             params: vec!["x".to_owned(), "y".to_owned(), "z".to_owned()],
             body: Box::new(Stmt::Block(vec![])),
             captured_env: None,
+            receiver: None,
         })
     ]);
 }
@@ -485,6 +486,7 @@ fn parses_fn_no_params() {
             params: vec![],
             body: Box::new(Stmt::Block(vec![])),
             captured_env: None,
+            receiver: None,
         })
     ]);
 }
@@ -515,6 +517,7 @@ fn parses_lambda() {
                     params: vec![],
                     body: Box::new(Stmt::Block(vec![])),
                     captured_env: None,
+                    receiver: None,
                 })
             ],
         })


### PR DESCRIPTION
This pull request adds support for `this` contexts inside of functions. It works by using `receiver` which is setup when the interpreter figures out where the method is coming from.

This feature will allow people to create pseudo-classes / structs with methods by creating dictionaries with a factory function that can then access `this` object:

```
let obj = {
    name: 'Ryan',
    getName: fn () {
        return this.name
    }
}

print(obj.getName()) // prints `Ryan`
```

I need to write some tests for this still, so it's a draft for now.

> I'm open to thoughts about the keyword / binding too. I chose `this` because it's most inline with JavaScript et al, but `self` could work too (like Rust) or you go down a completely different route and introduce a new token / sigil like `@` in Ruby.